### PR TITLE
Rewrite thread watcher

### DIFF
--- a/thread-watcher.py
+++ b/thread-watcher.py
@@ -3,6 +3,7 @@ from itertools import chain
 from urllib import request
 import argparse
 import json
+import re
 
 # TODO
 # add argument to have something like vg/monster-hunter/ and inside that dir all threads separated by their id
@@ -29,7 +30,7 @@ def main():
     parser = argparse.ArgumentParser(description='thread-watcher')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose')
     parser.add_argument('-b', '--board', help='board', required=True)
-    parser.add_argument('-q', '--query', help='search term', required=True)
+    parser.add_argument('-q', '--query', help='search term (supports regex)', required=True)
     parser.add_argument('-f', '--queuefile', help='queue file', required=True)
     parser.add_argument('-n', '--naming', help='dir name for saved threads', required=True)
     parser.add_argument('-u', '--thread-url', help='base url of the chans boards (default: https://boards.4chan.org/{board}/thread/{id}/{name})')
@@ -40,6 +41,7 @@ def main():
     name = args.naming.lower().replace(' ', '-')
     file = open(args.queuefile, 'a+')
     file.seek(0)
+    query = re.compile(args.query)
 
     ignored_lines = ['#', '-', '\n']
     queue_threads = [line.strip() for line in file if line[0] not in ignored_lines]
@@ -47,7 +49,7 @@ def main():
     for thread in get_threads(args.board, args.api_url):
         thread_url = url_template.format(board=args.board, id=thread['no'], name=name)
 
-        if args.query in thread.get('sub', thread.get('com', '')) and thread_url not in queue_threads:
+        if query.search(thread.get('sub', thread.get('com', ''))) and thread_url not in queue_threads:
             file.write('%s\n' % thread_url)
             if args.verbose:
                 print(thread_url)

--- a/thread-watcher.py
+++ b/thread-watcher.py
@@ -15,9 +15,11 @@ log = logging.getLogger('thread-watcher')
 workpath = os.path.dirname(os.path.realpath(__file__))
 args = None
 
+
 def load(url):
     req = request.Request(url, headers={'User-Agent': '4chan Browser'})
     return request.urlopen(req).read()
+
 
 def main():
     global args
@@ -59,9 +61,9 @@ def main():
                 f.write(thread)
                 f.write('\n')
 
+
 if __name__ == '__main__':
     try:
         main()
     except KeyboardInterrupt:
         pass
-

--- a/thread-watcher.py
+++ b/thread-watcher.py
@@ -18,7 +18,6 @@ THREAD_URL_TEMPLATE = 'https://boards.4chan.org/{board}/thread/{id}/{name}'
 def get_threads(board, url_template=None):
     template = url_template or API_URL_TEMPLATE
     url = template.format(board=board)
-    print(url)
     req = request.Request(url, headers={'User-Agent': '4chan Browser',
                                         'Content-Type': 'application/json'})
     content = request.urlopen(req).read().decode('utf-8')

--- a/thread-watcher.py
+++ b/thread-watcher.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python
-import urllib.request, urllib.error, urllib.parse, argparse, logging
-import os, re, time
-import http.client
-import fileinput
-from multiprocessing import Process
+from urllib import request
+import argparse
+import logging
+import os
+import re
 
 # TODO
 # add argument to have something like vg/monster-hunter/ and inside that dir all threads separated by their id
@@ -16,8 +16,8 @@ workpath = os.path.dirname(os.path.realpath(__file__))
 args = None
 
 def load(url):
-    req = urllib.request.Request(url, headers={'User-Agent': '4chan Browser'})
-    return urllib.request.urlopen(req).read()
+    req = request.Request(url, headers={'User-Agent': '4chan Browser'})
+    return request.urlopen(req).read()
 
 def main():
     global args
@@ -48,7 +48,7 @@ def main():
 
     ignored_lines = ['#', '-', '\n']
     queue_threads = [line.strip() for line in open(args.queuefile[0], 'r') if line[0] not in ignored_lines]
-    
+
     new_threads = list(set(current_threads) - set(queue_threads))
     if args.verbose:
         print(new_threads)
@@ -64,4 +64,4 @@ if __name__ == '__main__':
         main()
     except KeyboardInterrupt:
         pass
-                            
+

--- a/thread-watcher.py
+++ b/thread-watcher.py
@@ -52,16 +52,12 @@ def main():
     ignored_lines = ['#', '-', '\n']
     queue_threads = [line.strip() for line in file if line[0] not in ignored_lines]
 
-    threads = []
     for thread in get_threads(args.board):
         url = thread_url % thread['no']
         if args.query in thread.get('sub', '') and url not in queue_threads:
-            threads.append(url)
-
-    if args.verbose:
-        print(threads)
-
-    file.writelines(threads)
+            file.write('%s\n' % url)
+            if args.verbose:
+                print(url)
 
 
 if __name__ == '__main__':

--- a/thread-watcher.py
+++ b/thread-watcher.py
@@ -46,24 +46,22 @@ def main():
         board=args.board,
         name=name,
     )
-
-    current_threads = []
-    for thread in get_threads(args.board):
-        if args.query in thread.get('sub', ''):
-            current_threads.append(thread_url % thread['no'])
+    file = open(args.queuefile, 'a+')
+    file.seek(0)
 
     ignored_lines = ['#', '-', '\n']
-    queue_threads = [line.strip() for line in open(args.queuefile, 'r') if line[0] not in ignored_lines]
+    queue_threads = [line.strip() for line in file if line[0] not in ignored_lines]
 
-    new_threads = list(set(current_threads) - set(queue_threads))
+    threads = []
+    for thread in get_threads(args.board):
+        url = thread_url % thread['no']
+        if args.query in thread.get('sub', '') and url not in queue_threads:
+            threads.append(url)
+
     if args.verbose:
-        print(new_threads)
+        print(threads)
 
-    if len(new_threads) > 0:
-        with open(args.queuefile, 'a') as f:
-            for thread in new_threads:
-                f.write(thread)
-                f.write('\n')
+    file.writelines(threads)
 
 
 if __name__ == '__main__':

--- a/thread-watcher.py
+++ b/thread-watcher.py
@@ -13,7 +13,6 @@ import re
 
 log = logging.getLogger('thread-watcher')
 workpath = os.path.dirname(os.path.realpath(__file__))
-args = None
 
 
 def load(url):
@@ -22,23 +21,17 @@ def load(url):
 
 
 def main():
-    global args
     parser = argparse.ArgumentParser(description='thread-watcher')
     parser.add_argument('-v', '--verbose', action='store_true', help='verbose')
-    parser.add_argument('-b', '--board', nargs=1, help='board', required=True)
-    parser.add_argument('-q', '--query', nargs=1, help='search term', required=True)
-    parser.add_argument('-f', '--queuefile', nargs=1, help='queue file', required=True)
-    parser.add_argument('-n', '--naming', nargs=1, help='dir name for saved threads', required=True)
+    parser.add_argument('-b', '--board', help='board', required=True)
+    parser.add_argument('-q', '--query', help='search term', required=True)
+    parser.add_argument('-f', '--queuefile', help='queue file', required=True)
+    parser.add_argument('-n', '--naming', help='dir name for saved threads', required=True)
     args = parser.parse_args()
 
-    required_args = [args.board, args.query, args.queuefile, args.naming]
-    for arg in required_args:
-        if arg == None or len(arg) == 0 or len(arg[0]) == 0:
-            exit()
-
-    name = args.naming[0].lower().replace(' ', '-')
-    query = args.query[0]
-    base_url = 'https://boards.4chan.org/' + args.board[0] + '/'
+    name = args.naming.lower().replace(' ', '-')
+    query = args.query
+    base_url = 'https://boards.4chan.org/' + args.board + '/'
     catalog_url = base_url + 'catalog'
 
     current_threads = []
@@ -49,14 +42,14 @@ def main():
         current_threads.append(base_url + 'thread/' + threadid + '/' + name)
 
     ignored_lines = ['#', '-', '\n']
-    queue_threads = [line.strip() for line in open(args.queuefile[0], 'r') if line[0] not in ignored_lines]
+    queue_threads = [line.strip() for line in open(args.queuefile, 'r') if line[0] not in ignored_lines]
 
     new_threads = list(set(current_threads) - set(queue_threads))
     if args.verbose:
         print(new_threads)
 
     if len(new_threads) > 0:
-        with open(args.queuefile[0], 'a') as f:
+        with open(args.queuefile, 'a') as f:
             for thread in new_threads:
                 f.write(thread)
                 f.write('\n')


### PR DESCRIPTION
Rewrite thread watcher to improve readability, pep and customizability 

New: 
- Support regex in query
- Search subject and when not present search comment
- Define own api and url. Eg. when you want `4channel.org` or `8kun.top`
  eg. for 8kun you would do something like this
  ```bash
  python thread-watcher.py -b pnd -q "THREAD" -f queue.txt -n 'bla bla' -v -a 'https://8kun.top/{board}/catalog.json' -u 'https://8kun.top/{board}/res/{id}.html?name={name}'
  ```

PS: Other boards like 8kun are probably not yet supported by the `inb4404.py` script. I'll test/add this later or tomorrow.