### PR TITLE
Configurable threads

### DIFF
--- a/inb4404.py
+++ b/inb4404.py
@@ -5,7 +5,6 @@ import http.client
 import fileinput
 from multiprocessing import Process
 from multiprocessing import Lock, current_process, Manager
-#import queue
 
 
 log = logging.getLogger('inb4404')

--- a/inb4404.py
+++ b/inb4404.py
@@ -43,7 +43,9 @@ def main():
 
     thread = args.thread[0].strip()
     if thread[:4].lower() == 'http':
-        download_thread(thread, args)
+        while True:
+            download_thread(thread, args)
+            time.sleep(20)
     else:
         download_from_file(thread)
 


### PR DESCRIPTION
I added a lot between commits, which was a mistake, but the rundown is that I re-worked the threaded downloads.

Previously each 4chan thread would get its own process to check and download new images.
I created a queue (manager.list) system and made static workers/processes. By default, 4 will be created, but that is configurable with -p. As 'jobs' are pulled from the queue, a worker thread will work on it, then wait until another job is available to pull from the queue.

Let me know if you have any questions or want me to change anything.

Thanks!