### PR TITLE
Add support for pdf files

### DIFF
--- a/inb4404.py
+++ b/inb4404.py
@@ -78,7 +78,7 @@ def download_thread(thread_link, args):
 
     while True:
         try:
-            regex = '(\/\/i(?:s|)\d*\.(?:4cdn|4chan)\.org\/\w+\/(\d+\.(?:jpg|png|gif|webm)))'
+            regex = r'(\/\/i(?:s|)\d*\.(?:4cdn|4chan)\.org\/\w+\/(\d+\.(?:jpg|png|gif|webm|pdf)))'
             html_result = load(thread_link).decode('utf-8')
             regex_result = list(set(re.findall(regex, html_result)))
             regex_result = sorted(regex_result, key=lambda tup: tup[1])


### PR DESCRIPTION
pdf files are used in /po/ for posting origami patterns. I've made this tiny modification which allowed me to archive a thread from /po/ for preservation purposes, and I believe some people could benefit from this.

This also fixes the "SyntaxWarning: invalid escape sequence '\/'" message, which shows up when running the script and might lead some people to believe they did something wrong.