### PR TITLE
added thread ids to download folders

### DIFF
--- a/inb4404.py
+++ b/inb4404.py
@@ -17,6 +17,7 @@ def main():
     parser.add_argument('-d', '--date', action='store_true', help='show date as well')
     parser.add_argument('-l', '--less', action='store_true', help='show less information (surpresses checking messages)')
     parser.add_argument('-n', '--use-names', action='store_true', help='use thread names instead of the thread ids (...4chan.org/board/thread/thread-id/thread-name)')
+    parser.add_argument('-i', '--include-ids', action='store_true', help='include ids when using thread names')
     parser.add_argument('-r', '--reload', action='store_true', help='reload the queue file every 5 minutes')
     parser.add_argument('-t', '--title', action='store_true', help='save original filenames')
     parser.add_argument(      '--no-new-dir', action='store_true', help='don\'t create the `new` directory')
@@ -88,7 +89,10 @@ def download_thread(thread_link, args):
         thread_tmp = thread_link.split('/')[6].split('#')[0]
 
         if args.use_names or os.path.exists(os.path.join(workpath, 'downloads', board, thread_tmp)):                
-            thread = thread_tmp
+            if args.include_ids:
+                thread = f'{thread}-{thread_tmp}'
+            else:
+                thread = thread_tmp
 
     while True:
         try:


### PR DESCRIPTION
self-explanatory, helps with organizing threads in filesystem because directories are sorted by id, not name.

optional, not a fix, but a feature, feel free to reject if not of value.