### PR TITLE
Fix deprecated method

### DIFF
--- a/inb4404.py
+++ b/inb4404.py
@@ -70,11 +70,11 @@ def get_title_list(html_content):
     divs = parsed.find_all("div", {"class": "fileText"})
 
     for i in divs:
-        current_child = i.findChildren("a", recursive = False)[0]
+        first_child = i.find_all("a", recursive = False)[0]
         try:
-            ret.append(current_child["title"])
+            ret.append(first_child["title"])
         except KeyError:
-            ret.append(current_child.text)
+            ret.append(first_child.text)
 
     return ret
 


### PR DESCRIPTION
I don't know about anyone else, but BeautifulSoup4 complains about this deprecated method findChildren every time I execute the script. See warning:

Call to deprecated method findChildren. (Replaced by find_all) Deprecated since version 3.0.0.